### PR TITLE
Add multi-account login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ El bot utiliza la libreria de Selenium para interactuar con la plataforma. Puede
 
 ## Configuración
 
-Antes de ejecutar el bot, debes configurar tus credenciales de Instagram en el archivo `.env`. Asegúrate de incluir tu nombre de usuario y contraseña de Instagram.
+Antes de ejecutar el bot puedes configurar las credenciales de dos maneras:
+
+1. Usando un archivo `.env` con un único usuario.
+2. Creando un archivo `credentials.txt` con varias cuentas, una por línea.
+
+Ejemplo del archivo `.env`:
 
 ```python
 # .env
@@ -24,6 +29,15 @@ Antes de ejecutar el bot, debes configurar tus credenciales de Instagram en el a
 USERNAME = 'tu_nombre_de_usuario'
 PASSWORD = 'tu_contraseña'
 ```
+
+Formato de `credentials.txt`:
+
+```
+usuario1,clave1
+usuario2,clave2
+```
+
+Si `credentials.txt` existe, el bot utilizará todas las cuentas secuencialmente. De lo contrario, usará las variables del `.env`.
 
 ## Ejecución
 

--- a/credentials.txt
+++ b/credentials.txt
@@ -1,0 +1,2 @@
+user1,password1
+user2,password2

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from dotenv import load_dotenv
 import os
+from typing import List, Tuple
 
 load_dotenv()
 
@@ -13,6 +14,28 @@ USERNAME = os.getenv("USERNAME")
 PASSWORD = os.getenv("PASSWORD")
 MAX_TIME_LOAD = 20
 MIN_TIME_LOAD = 2
+
+
+def load_credentials(file_path: str = "credentials.txt") -> List[Tuple[str, str]]:
+    """Load multiple account credentials from a text file."""
+    credentials: List[Tuple[str, str]] = []
+    if not os.path.exists(file_path):
+        return credentials
+
+    with open(file_path, "r", encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" in line:
+                username, password = line.split(":", 1)
+            elif "," in line:
+                username, password = line.split(",", 1)
+            else:
+                continue
+            credentials.append((username.strip(), password.strip()))
+
+    return credentials
 
 xpath = {
    "decline_cookies": "/html/body/div[6]/div[1]/div/div[2]/div/div/div/div/div[2]/div/button[2]",
@@ -35,7 +58,9 @@ urls = {
 
 class InstaFollower:
 
-    def __init__(self):
+    def __init__(self, username: str, password: str):
+        self.username = username
+        self.password = password
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_experimental_option("detach", True)
         self.driver = webdriver.Chrome(options=chrome_options)
@@ -55,14 +80,14 @@ class InstaFollower:
         except:
             pass
 
-        username = self.driver.find_element(by=By.NAME, value="username")
-        password = self.driver.find_element(by=By.NAME, value="password")
+        username_input = self.driver.find_element(by=By.NAME, value="username")
+        password_input = self.driver.find_element(by=By.NAME, value="password")
 
-        username.send_keys(USERNAME)
-        password.send_keys(PASSWORD)
+        username_input.send_keys(self.username)
+        password_input.send_keys(self.password)
 
         WebDriverWait(self.driver, MIN_TIME_LOAD)
-        password.send_keys(Keys.ENTER)
+        password_input.send_keys(Keys.ENTER)
 
         try:
             # Click "Not now" and ignore Save-login info prompt
@@ -121,7 +146,13 @@ class InstaFollower:
                 cancel_button = self.driver.find_element(by=By.XPATH, value=xpath["cancel_unfollow_button"])
                 cancel_button.click()     
 
-bot = InstaFollower()
-bot.login()
-bot.find_followers("leomessi")
-bot.close_browser()
+if __name__ == "__main__":
+    credentials = load_credentials()
+    if not credentials and USERNAME and PASSWORD:
+        credentials = [(USERNAME, PASSWORD)]
+
+    for user, pwd in credentials:
+        bot = InstaFollower(user, pwd)
+        bot.login()
+        bot.find_followers("leomessi")
+        bot.close_browser()


### PR DESCRIPTION
## Summary
- load credentials from `credentials.txt`
- update the `InstaFollower` class to accept username and password
- iterate over all credentials when running the bot
- document multi-account setup in README
- add sample `credentials.txt`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68507471d174832fa9b2d6ad6f085456